### PR TITLE
Fixes MQTT names and units for some values in lfp4

### DIFF
--- a/internal/batteries/lifepower4.go
+++ b/internal/batteries/lifepower4.go
@@ -50,13 +50,13 @@ type LFP4AnalogValueBatteryInfo struct {
 	NumberOfCells     uint8      `skip:"1"` // 16 or 8, if it's 8, loading data will not work!
 	CellVoltages      [16]uint16 `name:"cell_%d_voltage" dclass:"voltage" unit:"V" multiplier:"0.001"`
 	_                 uint8      `skip:"1"` // always 4
-	CellTemps         [4]uint16  `name:"cell_temp_%d" dclass:"temperature" unit:"°K" multiplier:"0.1"`
-	EnvTemp           uint16     `name:"environment_temp" dclass:"temperature" unit:"°K" multiplier:"0.1"`
-	MOSFETTemp        uint16     `name:"mosfet_temp" dclass:"temperature" unit:"°K" multiplier:"0.1"`
+	CellTemps         [4]uint16  `name:"cell_temp_%d" dclass:"temperature" unit:"K" multiplier:"0.1"`
+	EnvTemp           uint16     `name:"environment_temp" dclass:"temperature" unit:"K" multiplier:"0.1"`
+	MOSFETTemp        uint16     `name:"mosfet_temp" dclass:"temperature" unit:"K" multiplier:"0.1"`
 	PackCurrent       int16      `name:"pack_current" dclass:"current" unit:"A" multiplier:"0.01"`
 	PackVoltage       int16      `name:"pack_voltage" dclass:"voltage" unit:"V" multiplier:"0.01"`
-	CapRemaining      uint16     `name:"remaining_capacity:" unit:"Ah" multiplier:"0.01"`
-	FullCapacity      uint16     `name:"full_capacity:" unit:"Ah" multiplier:"0.01"`
+	CapRemaining      uint16     `name:"remaining_capacity" unit:"Ah" multiplier:"0.01"`
+	FullCapacity      uint16     `name:"full_capacity" unit:"Ah" multiplier:"0.01"`
 	CycleCounts       uint16     `name:"cycle_counts" icon:"mdi:battery-sync"`
 	UserDefined       uint8      `name:"user_defined"`
 	SOC               uint16     `name:"soc" dclass:"battery" unit:"%"`
@@ -64,12 +64,12 @@ type LFP4AnalogValueBatteryInfo struct {
 	MaxCellVoltage    uint16     `name:"max_cell_voltage" dclass:"voltage" unit:"V" multiplier:"0.001"`
 	MinCellVoltage    uint16     `name:"min_cell_voltage" dclass:"voltage" unit:"V" multiplier:"0.001"`
 	CellVoltageDiff   uint16     `name:"diff_cell_voltage" dclass:"voltage" unit:"V" multiplier:"0.001"`
-	MaxCellTemp       uint16     `name:"max_cell_temp" dclass:"temperature" unit:"°K" multiplier:"0.1"`
-	MinCellTemp       uint16     `name:"min_cell_temp" dclass:"temperature" unit:"°K" multiplier:"0.1"`
+	MaxCellTemp       uint16     `name:"max_cell_temp" dclass:"temperature" unit:"K" multiplier:"0.1"`
+	MinCellTemp       uint16     `name:"min_cell_temp" dclass:"temperature" unit:"K" multiplier:"0.1"`
 	CumChargingCap    uint32     `name:"cumulative_charging_capacity" dclass:"current" unit:"A" multiplier:"0.01"`
 	CumDischargeCap   uint32     `name:"cumulative_discharge_capacity" dclass:"current" unit:"A" multiplier:"0.01"`
-	CumChargingPower  uint32     `name:"cumulative_charging_power" dclass:"power" unit:"kWh" multiplier:"0.001"`
-	CumDischargePower uint32     `name:"cumulative_discharge_power" dclass:"power" unit:"kWh" multiplier:"0.001"`
+	CumChargingPower  uint32     `name:"cumulative_charging_power" dclass:"power" unit:"kW" multiplier:"0.001"`
+	CumDischargePower uint32     `name:"cumulative_discharge_power" dclass:"power" unit:"kW" multiplier:"0.001"`
 	CumChargingTime   uint32     `name:"cumulative_charging_time" unit:"h"`
 	CumDischargeTime  uint32     `name:"cumulative_discharge_time" unit:"h"`
 	CumChargingTimes  uint16     `name:"cumulative_charging_times" unit:"h"`


### PR DESCRIPTION
-Homeassistant doesn't like the degree character ('°') for Kelvin -Remove bogus ':' at the end of the names for {full,remaining}_capacity -The unit for cumulative_{charging,discharging}_power is kW, not kWh.

Fixes issue #4.